### PR TITLE
Remove invalid invoice type codes 383 and 386 from UAE list

### DIFF
--- a/index.html
+++ b/index.html
@@ -950,14 +950,6 @@ Note that only 0 is currently supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Credit note, only applicable within UBL message/document type CreditNote.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>383</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Debit note, only applicable within UBL message/document type Invoice.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>386</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Prepayment invoice, only applicable within UBL message/document type Invoice.</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>480</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Out of scope of VAT, only applicable within UBL message/document type Invoice.</p></td>
 </tr>

--- a/specification/PUF-003-INVOICETYPECODE.adoc
+++ b/specification/PUF-003-INVOICETYPECODE.adoc
@@ -96,12 +96,6 @@ The below listed invoice type codes are available for use in the United Arab Emi
 |`381`
 |Credit note, only applicable within UBL message/document type CreditNote.
 
-|`383`
-|Debit note, only applicable within UBL message/document type Invoice.
-
-|`386`
-|Prepayment invoice, only applicable within UBL message/document type Invoice.
-
 |`480`
 |Out of scope of VAT, only applicable within UBL message/document type Invoice.
 


### PR DESCRIPTION
## Summary

The UAE section of PUF-003 (Invoice Type Codes) currently lists `383` (Debit note) and `386` (Prepayment invoice) as available for the UAE. Neither code is accepted by the official **Peppol PINT BIS Billing AE 1.0.3** target spec — its `UNCL1001-inv.gc` restricts invoice-type documents to `380` (Tax invoice) and `480` (Out of scope of tax). The FTA Electronic Invoicing Guidelines also make no mention of debit notes or prepayment invoices as distinct document types.

A PUF AE document carrying `InvoiceTypeCode = 383` or `386` will pass PUF schematron but cannot be transformed into a compliant PINT AE invoice. This change brings the UAE table in line with the target spec.

The UAE entries for `380`, `381`, `480`, and `81` are unchanged. The accompanying invalid Debit Note example in `puf-billing` is removed in pagero/puf-billing#165.

## Test plan

- [ ] Confirm asciidoctor render of `index.html` matches the .adoc change
- [ ] Confirm no other UAE-tagged documentation/examples in this repo reference `383` or `386`